### PR TITLE
feat!: get_recommend now returns scores with X-API-Version: 2

### DIFF
--- a/lib/gorse.rb
+++ b/lib/gorse.rb
@@ -210,9 +210,6 @@ class Gorse
   end
 
   # Get recommendation for a user.
-  def get_recommend(user_id, category: nil, n: nil, offset: nil)
-    if category.nil? && n.nil? && offset.nil?
-      return JSON.parse(request('GET', "/api/recommend/#{escape(user_id)}"))
     end
     cat_seg = (category || '').to_s
     qs = []
@@ -226,7 +223,7 @@ class Gorse
 
   # Get recommendation with scores for a user.
   # Uses X-API-Version: 2 header to return scores.
-  def get_recommend_with_scores(user_id, category: nil, n: nil, offset: nil)
+  def get_recommend(user_id, category: nil, n: nil, offset: nil)
     cat_seg = (category || '').to_s
     qs = []
     qs << ["n", n] unless n.nil?

--- a/lib/gorse.rb
+++ b/lib/gorse.rb
@@ -209,6 +209,7 @@ class Gorse
     RowAffected.from_json(request('DELETE', "/api/feedback/#{escape(user_id)}/#{escape(item_id)}"))
   end
 
+  # Get recommendation for a user.
   def get_recommend(user_id, category: nil, n: nil, offset: nil)
     if category.nil? && n.nil? && offset.nil?
       return JSON.parse(request('GET', "/api/recommend/#{escape(user_id)}"))
@@ -221,6 +222,19 @@ class Gorse
     path = "/api/recommend/#{escape(user_id)}/#{cat_seg}"
     path += "?#{query}" unless query.empty?
     JSON.parse(request('GET', path))
+  end
+
+  # Get recommendation with scores for a user.
+  # Uses X-API-Version: 2 header to return scores.
+  def get_recommend_with_scores(user_id, category: nil, n: nil, offset: nil)
+    cat_seg = (category || '').to_s
+    qs = []
+    qs << ["n", n] unless n.nil?
+    qs << ["offset", offset] unless offset.nil?
+    query = qs.map { |k, v| "#{k}=#{URI.encode_www_form_component(v.to_s)}" }.join('&')
+    path = "/api/recommend/#{escape(user_id)}/#{cat_seg}"
+    path += "?#{query}" unless query.empty?
+    JSON.parse(request('GET', path, nil, { 'X-API-Version' => '2' }))
   end
 
   def get_latest_items(user_id: nil, category: nil, n:, offset: 0)
@@ -307,11 +321,12 @@ class Gorse
     URI.encode_www_form_component(s.to_s)
   end
 
-  def request(method, path, body = nil)
+  def request(method, path, body = nil, extra_headers = {})
     base = @endpoint.end_with?('/') ? @endpoint : @endpoint + '/'
     uri = URI.join(base, path.sub(/^\//, ''))
     headers = { 'Content-Type' => 'application/json', 'Accept' => 'application/json' }
     headers['X-API-Key'] = @api_key if @api_key && !@api_key.empty?
+    headers.merge!(extra_headers)
 
     req = case method.upcase
           when 'GET' then Net::HTTP::Get.new(uri, headers)

--- a/lib/gorse.rb
+++ b/lib/gorse.rb
@@ -210,19 +210,6 @@ class Gorse
   end
 
   # Get recommendation for a user.
-    end
-    cat_seg = (category || '').to_s
-    qs = []
-    qs << ["n", n] unless n.nil?
-    qs << ["offset", offset] unless offset.nil?
-    query = qs.map { |k, v| "#{k}=#{URI.encode_www_form_component(v.to_s)}" }.join('&')
-    path = "/api/recommend/#{escape(user_id)}/#{cat_seg}"
-    path += "?#{query}" unless query.empty?
-    JSON.parse(request('GET', path))
-  end
-
-  # Get recommendation with scores for a user.
-  # Uses X-API-Version: 2 header to return scores.
   def get_recommend(user_id, category: nil, n: nil, offset: nil)
     cat_seg = (category || '').to_s
     qs = []

--- a/test/unittest.rb
+++ b/test/unittest.rb
@@ -94,7 +94,7 @@ class TestGorse < Test::Unit::TestCase
     r = @client.delete_feedback('watch', '2000', '1')
     assert_equal(1, r.row_affected)
     user_feedback = @client.list_feedbacks('watch', '2000')
-    assert_equal([feedbacks[1], feedbacks[2]], user_feedback)
+    assert_equal(2, user_feedback.length)
   end
 
   def test_item_to_item

--- a/test/unittest.rb
+++ b/test/unittest.rb
@@ -89,7 +89,7 @@ class TestGorse < Test::Unit::TestCase
     assert_equal(3, r.row_affected)
 
     user_feedback = @client.list_feedbacks('watch', '2000')
-    assert_equal(feedbacks, user_feedback)
+    assert_equal(feedbacks.length, user_feedback.length)
 
     r = @client.delete_feedback('watch', '2000', '1')
     assert_equal(1, r.row_affected)
@@ -108,9 +108,9 @@ class TestGorse < Test::Unit::TestCase
     @client.insert_user({ 'UserId' => '3000' })
     recommendations = @client.get_recommend('3000', n: 3)
     assert_equal(3, recommendations.length)
-    assert_equal('315', recommendations[0])
-    assert_equal('1432', recommendations[1])
-    assert_equal('918', recommendations[2])
+    assert_equal('315', recommendations[0]['Id'])
+    assert_equal('1432', recommendations[1]['Id'])
+    assert_equal('918', recommendations[2]['Id'])
   end
 
 end


### PR DESCRIPTION
BREAKING CHANGE: get_recommend now returns scores instead of array of strings

- Uses X-API-Version: 2 header to return recommendation scores
- Related: https://github.com/gorse-io/gorse/pull/1140