### PR TITLE
feat: add SearchItems API

### DIFF
--- a/lib/gorse.rb
+++ b/lib/gorse.rb
@@ -295,6 +295,10 @@ class Gorse
     JSON.parse(request('GET', "/api/items?n=#{n}&cursor=#{URI.encode_www_form_component(cursor)}"))
   end
 
+  def search_items(query, n: 10)
+    JSON.parse(request('GET', "/api/items?q=#{URI.encode_www_form_component(query)}&n=#{n}"))
+  end
+
   def delete_item(item_id)
     RowAffected.from_json(request('DELETE', "/api/item/#{escape(item_id)}"))
   end

--- a/test/unittest.rb
+++ b/test/unittest.rb
@@ -37,6 +37,10 @@ class TestGorse < Test::Unit::TestCase
   end
 
   def test_items
+    search_result = @client.search_items('Toy Story', n: 3)
+    assert(!search_result['Items'].empty?)
+    assert_equal('Toy Story (1995)', search_result['Items'][0]['Comment'])
+
     data = @client.get_items(n: 3)
     cursor = data['Cursor']
     items = data['Items']


### PR DESCRIPTION
## Summary
- Adds `search_items` with URL-encoded query parameters.
- Call `GET /api/items?q=<query>&n=<n>` following gorse-io/gorse-go#16
- Add item-search integration coverage

## Test Plan
- `docker run ... ruby -Itest test/unittest.rb --name=/test_items/`
